### PR TITLE
Add preflight handler

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -124,9 +124,6 @@ class Auth {
         { baseUrl: this.options.baseUrl || this.client.options.baseUrl });
 
     return this.client.post(uri, fetchOptions)
-      .then((response) => {
-        return response.json();
-      })
       .then((data) => {
         this.client.storage.setItem('access_token', data); return data;
       });

--- a/src/bukalapak.js
+++ b/src/bukalapak.js
@@ -64,10 +64,10 @@ class Bukalapak {
       // enhance this later...
       if (this.auth) {
         return this.auth.formatRequest(reqUrl, opts).then((options) => {
-          return this._fetch(reqUrl, options);
+          return this._fetch(reqUrl, options).then(this._handlePreflight);
         });
       } else {
-        return this._fetch(reqUrl, opts);
+        return this._fetch(reqUrl, opts).then(this._handlePreflight);
       }
     };
   }
@@ -106,6 +106,20 @@ class Bukalapak {
     }
 
     return baseUrl;
+  }
+
+  // return real response when request is preflighted
+  // what is preflight? read these
+  // http://damon.ghost.io/killing-cors-preflight-requests-on-a-react-spa/
+  // https://remysharp.com/2011/04/21/getting-cors-working
+  _handlePreflight (response) {
+    if (!isUndefined(response.json)) {
+      return response.json();
+    } else {
+      return new Promise((resolve) => {
+        resolve(response);
+      });
+    }
   }
 }
 

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -36,7 +36,7 @@ describe('api', () => {
   describe('me()', () => {
     it('should return valid response', () => {
       let promise = client.api.me().then((response) => {
-        return response.json();
+        return response;
       });
 
       return Promise.all([
@@ -47,7 +47,7 @@ describe('api', () => {
 
     it('should return valid response with query', () => {
       let promise = client.api.me({ foo: 'bar' }).then((response) => {
-        return response.json();
+        return response;
       });
 
       return Promise.all([
@@ -58,7 +58,7 @@ describe('api', () => {
 
     it('should return valid response with query and custom headers', () => {
       let promise = client.api.me({ foo: 'bar' }, { headers: { 'Accept': 'application/json' } }).then((response) => {
-        return response.json();
+        return response;
       });
 
       return Promise.all([

--- a/test/auth_test.js
+++ b/test/auth_test.js
@@ -109,7 +109,7 @@ describe('auth adapter: token', () => {
   describe('client credentials', () => {
     it('should attach client credentials token in request headers', (done) => {
       let promise = client.get('/tests/request-token').then((response) => {
-        return response.json();
+        return response;
       });
       let wanted = {
         accept: 'application/vnd.bukalapak.v4+json',
@@ -129,7 +129,7 @@ describe('auth adapter: token', () => {
 
     it('should attach resource owner password token in request headers', (done) => {
       let promise = client.get('/tests/request-token').then((response) => {
-        return response.json();
+        return response;
       });
       let wanted = {
         accept: 'application/vnd.bukalapak.v4+json',
@@ -150,7 +150,7 @@ describe('auth adapter: token', () => {
 
     it('should attach client credentials token in request headers', (done) => {
       let promise = client.get('/tests/request-token').then((response) => {
-        return response.json();
+        return response;
       });
       let wanted = {
         accept: 'application/vnd.bukalapak.v4+json',
@@ -193,7 +193,7 @@ describe('auth adapter: auto refresh token', () => {
 
     it('should auto-refresh resource owner password token before attach it in request headers', (done) => {
       let promise = client.get('/tests/request-token').then((response) => {
-        return response.json();
+        return response;
       });
       let wanted = {
         accept: 'application/vnd.bukalapak.v4+json',
@@ -230,7 +230,7 @@ describe('auth adapter: auto refresh token with client credentials token)', () =
   describe('resource owner password', () => {
     it('should not auto-refresh client credentials token', (done) => {
       let promise = client.get('/tests/request-token').then((response) => {
-        return response.json();
+        return response;
       });
 
       let wanted = {

--- a/test/bukalapak_test.js
+++ b/test/bukalapak_test.js
@@ -94,7 +94,7 @@ describe('Bukalapak', () => {
       let options = { baseUrl: 'http://localhost:8088', storage: localStorage };
       let client = new Bukalapak(options);
       let promise = client.get('/tests/methods').then((response) => {
-        return response.json();
+        return response;
       });
       expect(promise).to.eventually.have.deep.property('method', 'GET').notify(done);
     });
@@ -103,7 +103,7 @@ describe('Bukalapak', () => {
       let options = { baseUrl: 'http://localhost:8088/', storage: localStorage };
       let client = new Bukalapak(options);
       let promise = client.get('/tests/methods').then((response) => {
-        return response.json();
+        return response;
       });
       expect(promise).to.eventually.have.deep.property('method', 'GET').notify(done);
     });
@@ -123,28 +123,28 @@ describe('Bukalapak', () => {
 
     it('should auto set body for post request', (done) => {
       let promise = client.post('/tests/post-blank-data').then((response) => {
-        return response.json();
+        return response;
       });
       expect(promise).to.eventually.eql({ body: {} }).notify(done);
     });
 
     it('should able to perform delete request', (done) => {
       let promise = client.del('/tests/methods').then((response) => {
-        return response.json();
+        return response;
       });
       expect(promise).to.eventually.have.deep.property('method', 'DELETE').notify(done);
     });
 
     it('should able to perform options request', (done) => {
       let promise = client.opts('/tests/methods').then((response) => {
-        return response.json();
+        return response;
       });
       expect(promise).to.eventually.have.deep.property('method', 'OPTIONS').notify(done);
     });
 
     it('should handle not authorized error properly', () => {
       let promise = client.get('/tests/unauthorized').then((response) => {
-        return response.json();
+        return response;
       });
 
       return Promise.all([
@@ -157,7 +157,7 @@ describe('Bukalapak', () => {
     it('should be able to switch baseUrl', (done) => {
       let client = new Bukalapak({ baseUrl: 'http://api.lvh.me:8088', storage: localStorage });
       let promise = client.get('/tests/domain', { baseUrl: 'http://accounts.lvh.me:8088' }).then((response) => {
-        return response.json();
+        return response;
       });
       expect(promise).to.eventually.eql({ host: 'accounts.lvh.me:8088' }).notify(done);
     });
@@ -165,7 +165,7 @@ describe('Bukalapak', () => {
     it('should be able to set custom headers', () => {
       let options = { headers: { 'Accept': 'application/json', 'User-Agent': 'bukalapak.js//0.0.0' } };
       let promise = client.get('/tests/http-headers', options).then((response) => {
-        return response.json();
+        return response;
       });
 
       return Promise.all([
@@ -179,7 +179,7 @@ describe('Bukalapak', () => {
         it('should return error for invalid scope', () => {
           let httpPath = Util.oauthPath({ grant_type: 'client_credentials', scope: 'unkn0wn' });
           let promise = client.post(httpPath).then((response) => {
-            return response.json();
+            return response;
           });
 
           return Promise.all([
@@ -191,7 +191,7 @@ describe('Bukalapak', () => {
         it('should generate token for valid client credentials request', () => {
           let httpPath = Util.oauthPath({ grant_type: 'client_credentials', scope: 'public' });
           let promise = client.post(httpPath).then((response) => {
-            return response.json();
+            return response;
           });
 
           return Promise.all([
@@ -209,7 +209,7 @@ describe('Bukalapak', () => {
         it('should return error for missing username and password', () => {
           let httpPath = Util.oauthPath({ grant_type: 'password' });
           let promise = client.post(httpPath).then((response) => {
-            return response.json();
+            return response;
           });
 
           return Promise.all([
@@ -221,7 +221,7 @@ describe('Bukalapak', () => {
         it('should generate token for valid resource owner password credentials request', () => {
           let httpPath = Util.oauthPath({ grant_type: 'password', scope: 'public user', username: 'foo', password: 's3cr3t' });
           let promise = client.post(httpPath).then((response) => {
-            return response.json();
+            return response;
           });
 
           return Promise.all([
@@ -239,7 +239,7 @@ describe('Bukalapak', () => {
         it('should return error for missing refresh_token', () => {
           let httpPath = Util.oauthPath({ grant_type: 'refresh_token', access_token: 'abcdef' });
           let promise = client.post(httpPath).then((response) => {
-            return response.json();
+            return response;
           });
 
           return Promise.all([
@@ -251,7 +251,7 @@ describe('Bukalapak', () => {
         it('should generate token for valid refresh token request', () => {
           let httpPath = Util.oauthPath({ grant_type: 'refresh_token', scope: 'public user', access_token: 'abcdef', refresh_token: 'zxcv' });
           let promise = client.post(httpPath).then((response) => {
-            return response.json();
+            return response;
           });
 
           return Promise.all([

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -47,7 +47,7 @@ describe('integration', () => {
   it('use api adapter (as client)', () => {
     client.useAdapter('api');
 
-    let promise = client.api.products().then((response) => { return response.json(); });
+    let promise = client.api.products();
 
     return Promise.all([
       expect(promise).to.eventually.have.property('data'),
@@ -70,7 +70,7 @@ describe('integration', () => {
   });
 
   it('use api adapter (as user)', () => {
-    let promise = client.api.me().then((response) => { return response.json(); });
+    let promise = client.api.me();
 
     return Promise.all([
       expect(promise).to.eventually.have.deep.property('data.username', 'subosito'),
@@ -101,7 +101,7 @@ describe('integration', () => {
 
     client.storage.setItem('access_token', clientToken);
 
-    let promise = client.api.products().then((response) => { return response.json(); });
+    let promise = client.api.products();
 
     return Promise.all([
       expect(promise).to.eventually.have.property('data'),


### PR DESCRIPTION
Mas @subosito

Ini ada tambahan buat menangani preflight Mas, tolong di-review.

Jadi client bisa langsung 

```javascript
client.api.products().then((response) => {/*do something with response*/});
```

daripada 

```javascript
client.api.products()
  .then((response) => {return response.json();})
  .then((response) => {/*do something with response*/});
```

Mengenai preflight:
http://damon.ghost.io/killing-cors-preflight-requests-on-a-react-spa/
https://remysharp.com/2011/04/21/getting-cors-working

Terima kasih