### PR TITLE
Remove stored password in auth object after login

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -52,12 +52,15 @@ class Auth {
 
     this.options.username = username;
     this.options.password = password;
-    return this.userAuth();
+
+    let authResponse = this.userAuth();
+    delete this.options.password;
+
+    return authResponse;
   }
 
   logout () {
     delete this.options.username;
-    delete this.options.password;
     return this.clientAuth();
   }
 

--- a/src/auth.js
+++ b/src/auth.js
@@ -20,10 +20,10 @@ class Auth {
           scope: this.scope
         };
       },
-      authPair (password) {
+      authPair (grantOptions) {
         return {
           username: this.username,
-          password: password
+          password: grantOptions.password
         };
       }
     };
@@ -156,7 +156,7 @@ class Auth {
       case 'refresh_token':
         return this._refreshTokenBuilder();
       case 'password':
-        return this._passwordBuilder(tokenGrant.options.password);
+        return this._passwordBuilder(tokenGrant.options);
     }
   }
 
@@ -178,11 +178,11 @@ class Auth {
     });
   }
 
-  _passwordBuilder (password) {
-    if (isBlank(this.options.username) || isBlank(password)) {
+  _passwordBuilder (grantOptions) {
+    if (isBlank(this.options.username) || isBlank(grantOptions.password)) {
       throw new Error('Unable to perform resource owner password credentials request');
     }
-    return Object.assign({}, this.options.toParams(), this.options.authPair(password), { grant_type: 'password' });
+    return Object.assign({}, this.options.toParams(), this.options.authPair(grantOptions), { grant_type: 'password' });
   }
 
   _validOptionKeys () {

--- a/src/auth.js
+++ b/src/auth.js
@@ -67,13 +67,12 @@ class Auth {
   }
 
   userAuth (password) {
-    return this._doRequest(this._authTokenUri(
-          {
-            grantFlow: 'password',
-            options: {
-              password: password
-            }
-          }));
+    return this._doRequest(this._authTokenUri({
+      grantFlow: 'password',
+      options: {
+        password: password
+      }
+    }));
   }
 
   refreshToken () {

--- a/src/auth.js
+++ b/src/auth.js
@@ -62,14 +62,14 @@ class Auth {
 
   clientAuth () {
     return this._doRequest(this._authTokenUri({
-      tokenGrantFlow: 'client_credentials'
+      grantFlow: 'client_credentials'
     }));
   }
 
   userAuth (password) {
     return this._doRequest(this._authTokenUri(
           {
-            tokenGrantFlow: 'password',
+            grantFlow: 'password',
             options: {
               password: password
             }
@@ -78,7 +78,7 @@ class Auth {
 
   refreshToken () {
     return this._doRequest(this._authTokenUri({
-      tokenGrantFlow:'refresh_token'
+      grantFlow:'refresh_token'
     }));
   }
 
@@ -150,7 +150,7 @@ class Auth {
   }
 
   _authTokenBuilder (tokenGrant) {
-    switch (tokenGrant.tokenGrantFlow) {
+    switch (tokenGrant.grantFlow) {
       case 'client_credentials':
         return this._clientCredentialsBuilder();
       case 'refresh_token':


### PR DESCRIPTION
Tolong reviewnya mas @subosito :bowing_man: 

Plaintext password yang disimpan di `options` dihapus setelah login supaya tidak accessible lagi dan untuk menghindari password ter-expose by accident saat proses debugging.

Flownya saya modifikasi supaya hasil dari function call `userAuth()` disimpan ke dalam object `authResponse` dulu supaya konsisten dengan pola sebelumnya di mana parameter-parameter yang dipakai dalam flow login disimpan di dalam object `options`. Tapi karena passwordnya sendiri cuma dipakai sekali saja, apa mungkin sebaiknya untuk password saya pass sebagai parameter untuk setiap function call dari login flow yang butuh password di dalamnya?