### PR TITLE
Prevent preflight for GET request

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -1,4 +1,4 @@
-import { parse as urlParse} from 'url';
+import { parse as urlParse } from 'url';
 import queryString from 'query-string';
 import { isBlank } from './util';
 
@@ -78,7 +78,7 @@ class Auth {
 
   refreshToken () {
     return this._doRequest(this._authTokenUri({
-      grantFlow:'refresh_token'
+      grantFlow: 'refresh_token'
     }));
   }
 
@@ -87,7 +87,7 @@ class Auth {
       let qs = urlParse(url).query;
       let sep = isBlank(qs) ? '?' : '&';
       return url + sep + `access_token=${token.access_token}`;
-    }
+    };
 
     let formatOptions = (token) => {
       let url = reqUrl;

--- a/src/auth.js
+++ b/src/auth.js
@@ -1,3 +1,4 @@
+import { parse as urlParse} from 'url';
 import queryString from 'query-string';
 import { isBlank } from './util';
 
@@ -82,12 +83,24 @@ class Auth {
   }
 
   formatRequest (reqUrl, options) {
+    let appendTokenToUrl = (url, token) => {
+      let qs = urlParse(url).query;
+      let sep = isBlank(qs) ? '?' : '&';
+      return url + sep + `access_token=${token.access_token}`;
+    }
+
     let formatOptions = (token) => {
+      let url = reqUrl;
+
       if (!reqUrl.match('grant_type=')) {
-        options.headers['Authorization'] = `Bearer ${token.access_token}`;
+        if (options.method === 'GET') {
+          url = appendTokenToUrl(url, token);
+        } else {
+          options.headers['Authorization'] = `Bearer ${token.access_token}`;
+        }
       }
 
-      return options;
+      return { url, options };
     };
 
     return new Promise((resolve, reject) => {

--- a/src/auth.js
+++ b/src/auth.js
@@ -26,7 +26,8 @@ class Auth {
           username: this.username,
           password: grantOptions.password
         };
-      }
+      },
+      accessTokenParam: false
     };
 
     this.options.fetchOptions = {};
@@ -93,7 +94,7 @@ class Auth {
       let url = reqUrl;
 
       if (!reqUrl.match('grant_type=')) {
-        if (options.method === 'GET') {
+        if (this.options.accessTokenParam) {
           url = appendTokenToUrl(url, token);
         } else {
           options.headers['Authorization'] = `Bearer ${token.access_token}`;
@@ -198,7 +199,7 @@ class Auth {
   }
 
   _validOptionKeys () {
-    return ['clientId', 'clientSecret', 'username', 'password', 'scope', 'tokenPath', 'baseUrl'];
+    return ['clientId', 'clientSecret', 'username', 'password', 'scope', 'tokenPath', 'baseUrl', 'accessTokenParam'];
   }
 
   _token_path () {

--- a/src/bukalapak.js
+++ b/src/bukalapak.js
@@ -63,8 +63,8 @@ class Bukalapak {
 
       // enhance this later...
       if (this.auth) {
-        return this.auth.formatRequest(reqUrl, opts).then((options) => {
-          return this._fetch(reqUrl, options);
+        return this.auth.formatRequest(reqUrl, opts).then(({ url, options }) => {
+          return this._fetch(url, options);
         });
       } else {
         return this._fetch(reqUrl, opts);

--- a/test/app.js
+++ b/test/app.js
@@ -87,7 +87,7 @@ app.get('/tests/http-headers', (req, res, next) => {
 
 app.route('/tests/request-token')
   .get((req, res, next) => {
-    res.status(200).json({ accept: req.headers.accept, query: req.query });
+    res.status(200).json({ accept: req.headers.accept, authorization: req.headers.authorization, query: req.query });
   })
   .post((req, res, next) => {
     res.status(200).json({ accept: req.headers.accept, authorization: req.headers.authorization, params: req.params });

--- a/test/app.js
+++ b/test/app.js
@@ -87,10 +87,10 @@ app.get('/tests/http-headers', (req, res, next) => {
 
 app.route('/tests/request-token')
   .get((req, res, next) => {
-    res.status(200).json({ accept: req.headers.accept, authorization: req.headers.authorization });
+    res.status(200).json({ accept: req.headers.accept, query: req.query });
   })
   .post((req, res, next) => {
-    res.status(200).json({ accept: req.headers.accept, params: req.params });
+    res.status(200).json({ accept: req.headers.accept, authorization: req.headers.authorization, params: req.params });
   });
 
 app.post('/tests/oauth-token', (req, res, next) => {

--- a/test/auth_test.js
+++ b/test/auth_test.js
@@ -107,17 +107,52 @@ describe('auth adapter: token', () => {
   });
 
   describe('client credentials', () => {
-    it('should attach client credentials token in request headers', (done) => {
-      let promise = client.get('/tests/request-token').then((response) => {
-        return response.json();
-      });
-      let wanted = {
-        accept: 'application/vnd.bukalapak.v4+json',
-        authorization: `Bearer ${validResponse.clientCredentials.access_token}`
-      };
+    describe('GET request', function (done) {
+      it('should attach client credentials token in request query string', function () {
+        let promise = client.get('/test/request-token').then((response) => {
+          return response.json();
+        });
+        let wanted = {
+          accept: 'application/vnd.bukalapak.v4+json',
+          query: {
+            access_token: validResponse.clientCredentials.access_token
+          }
+        };
 
-      expect(promise).to.eventually.eql(wanted).notify(done);
+        expect(promise).to.eventually.eql(wanted).notify(done);
+      });
+
+      it('should append client credentials token in request query string', function () {
+        let promise = client.get('/test/request-token?foo=bar').then((response) => {
+          return response.json();
+        });
+        let wanted = {
+          accept: 'application/vnd.bukalapak.v4+json',
+          query: {
+            foo: 'bar',
+            access_token: validResponse.clientCredentials.access_token
+          }
+        };
+
+        expect(promise).to.eventually.eql(wanted).notify(done);
+      });
     });
+
+    describe('POST request', function () {
+      it('should attach client credentials token in request headers', (done) => {
+        let promise = client.post('/tests/request-token').then((response) => {
+          return response.json();
+        });
+        let wanted = {
+          accept: 'application/vnd.bukalapak.v4+json',
+          authorization: `Bearer ${validResponse.clientCredentials.access_token}`,
+          params: {}
+        };
+
+        expect(promise).to.eventually.eql(wanted).notify(done);
+      });
+    });
+
   });
 
   describe('resource owner password', () => {
@@ -127,13 +162,15 @@ describe('auth adapter: token', () => {
       });
     });
 
-    it('should attach resource owner password token in request headers', (done) => {
+    it('should attach resource owner password token in query parameter', (done) => {
       let promise = client.get('/tests/request-token').then((response) => {
         return response.json();
       });
       let wanted = {
         accept: 'application/vnd.bukalapak.v4+json',
-        authorization: `Bearer ${validResponse.password.access_token}`
+        query: {
+          access_token: validResponse.password.access_token
+        }
       };
 
       expect(promise).to.eventually.eql(wanted).notify(done);
@@ -148,13 +185,15 @@ describe('auth adapter: token', () => {
       ]);
     });
 
-    it('should attach client credentials token in request headers', (done) => {
+    it('should attach client credentials token in request query string', (done) => {
       let promise = client.get('/tests/request-token').then((response) => {
         return response.json();
       });
       let wanted = {
         accept: 'application/vnd.bukalapak.v4+json',
-        authorization: `Bearer ${validResponse.clientCredentials.access_token}`
+        query: {
+          access_token: validResponse.clientCredentials.access_token
+        }
       };
 
       expect(promise).to.eventually.eql(wanted).notify(done);
@@ -191,13 +230,15 @@ describe('auth adapter: auto refresh token', () => {
       });
     });
 
-    it('should auto-refresh resource owner password token before attach it in request headers', (done) => {
+    it('should auto-refresh resource owner password token before attach it in request query string', (done) => {
       let promise = client.get('/tests/request-token').then((response) => {
         return response.json();
       });
       let wanted = {
         accept: 'application/vnd.bukalapak.v4+json',
-        authorization: `Bearer ${validResponse.refreshToken.access_token}`
+        query: {
+          access_token: validResponse.refreshToken.access_token
+        }
       };
 
       expect(promise).to.eventually.eql(wanted).notify(done);
@@ -235,7 +276,9 @@ describe('auth adapter: auto refresh token with client credentials token)', () =
 
       let wanted = {
         accept: 'application/vnd.bukalapak.v4+json',
-        authorization: `Bearer ${validResponse.clientCredentials.access_token}`
+        query: {
+          access_token: validResponse.clientCredentials.access_token
+        }
       };
 
       expect(promise).to.eventually.eql(wanted).notify(done);

--- a/test/auth_test.js
+++ b/test/auth_test.js
@@ -152,7 +152,6 @@ describe('auth adapter: token', () => {
         expect(promise).to.eventually.eql(wanted).notify(done);
       });
     });
-
   });
 
   describe('resource owner password', () => {


### PR DESCRIPTION
Added `accessTokenParam` option in auth adapter to append `access_token` in query parameter.

http://damon.ghost.io/killing-cors-preflight-requests-on-a-react-spa/